### PR TITLE
Fix QR code parsing bug

### DIFF
--- a/lib/modules/home/pages/qr_page.dart
+++ b/lib/modules/home/pages/qr_page.dart
@@ -67,7 +67,7 @@ class _QRPageState extends State<QRPage> with BaseSingleton {
                 [
                   TimeOfDay.fromDateTime(now),
                 ],
-                decripted.contains("|||'")
+                decripted.contains("|||")
                     ? decripted.split('|||').last
                     : decripted.split('|')[1],
               ),


### PR DESCRIPTION
## Summary
- fix incorrect substring check when parsing QR codes

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd3524f108323a81cf76c442e1d02